### PR TITLE
Update snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: liferea 
 base: core18 
-version: 'v1.12.7'
+version: '1.13.8'
 summary: Liferea is a desktop feed reader/news aggregator
 license: GPL-2.0
 description: |
@@ -81,7 +81,7 @@ parts:
     source: https://github.com/lwindolf/liferea.git
     source-type: git
     plugin: autotools
-    source-tag: v1.12.7
+    source-tag: v1.13.8
     override-build: |
       ./autogen.sh
       ./configure --prefix=/usr
@@ -106,6 +106,7 @@ parts:
       - python3-gi-cairo
       - appmenu-gtk3-module
       - libcurl4-openssl-dev
+      - libfribidi0
     build-packages:
       - intltool
       - flex
@@ -118,3 +119,4 @@ parts:
       - libxslt1-dev
       - gsettings-desktop-schemas-dev
       - libgirepository1.0-dev
+      - libfribidi-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,8 @@ adopt-info: liferea
 
 architectures:
   - build-on: amd64
-    run-on: amd64
+  - build-on: arm64
+  - build-on: armhf
 
 apps:
   liferea:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: liferea 
 base: core18 
-version: '1.13.8'
 summary: Liferea is a desktop feed reader/news aggregator
 license: GPL-2.0
 description: |
@@ -12,6 +11,7 @@ description: |
 grade: stable
 confinement: strict 
 compression: lzo
+adopt-info: liferea
 
 architectures:
   - build-on: amd64
@@ -78,6 +78,7 @@ parts:
   liferea:
     override-pull: |
       snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//')"
       sed -i.bak -e 's|Icon=liferea|Icon=/usr/share/icons/hicolor/scalable/apps/liferea.svg|g' net.sourceforge.liferea.desktop.in
     source: https://github.com/lwindolf/liferea.git
     source-type: git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,7 @@ apps:
       - desktop 
       - desktop-legacy #
       - opengl
+      - audio-playback
   liferea-add-feed:
     slots:
     - dbus-liferea
@@ -96,8 +97,10 @@ parts:
       - python3-gi
       - git
       - python-gi
-      - libgstreamer-gl1.0-0
-      - libgstreamer-plugins-bad1.0-0
+      - gstreamer1.0-alsa
+      - gstreamer1.0-plugins-base
+      - gstreamer1.0-plugins-good
+      - gstreamer1.0-pulseaudio
       - libgstreamer-plugins-base1.0-0
       - libgstreamer-plugins-good1.0-0
       - libgstreamer1.0-0
@@ -110,6 +113,11 @@ parts:
       - appmenu-gtk3-module
       - libcurl4-openssl-dev
       - libfribidi0
+      - libgl1
+      - libglu1-mesa
+      - freeglut3
+      - libgpm2
+      - libslang2
     build-packages:
       - intltool
       - flex

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,7 @@ description: |
 
 grade: stable
 confinement: strict 
+compression: lzo
 
 architectures:
   - build-on: amd64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,7 +81,7 @@ parts:
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "$(git describe --tags | sed 's/^v//')"
-      sed -i.bak -e 's|Icon=liferea|Icon=/usr/share/icons/hicolor/scalable/apps/liferea.svg|g' net.sourceforge.liferea.desktop.in
+      sed -i.bak -E 's|Icon=.+|Icon=/usr/share/icons/hicolor/scalable/apps/net.sourceforge.liferea.svg|g' net.sourceforge.liferea.desktop.in
     source: https://github.com/lwindolf/liferea.git
     source-type: git
     plugin: autotools


### PR DESCRIPTION
Hi! Are you interested in reviving the Liferea snap?

I updated snapcraft.yaml to make it pull from version 1.13.8 by default, use the correct icons, and make the media player plugin work again.

I also replaced the hardcoded version by one generated from git-describe, so it just uses the same version as the git tag used to build the snap or from generated version when built from a branch -- that's nice for having an edge channel built automatically from master, so people wanting the latest features can have them automatically.

Hope this will be useful!
